### PR TITLE
getobjbound() returns info from tim.lst

### DIFF
--- a/src/BARON.jl
+++ b/src/BARON.jl
@@ -388,18 +388,17 @@ function read_results(m::BaronMathProgModel)
     # http://www.minlp.com/downloads/docs/baron%20manual.pdf
     fp = open(m.timfile, "r")
     tl = split(readline(fp))
+    length(tl) < 1 && error("No detection of tim file line.")
 
     # Even if infeasible, objective bounds can still be obtained
     m.sense == :Min ? bdidx = 6 : bdidx = 7
-    # Special case to handle scientific notation
-    # If bound value string is "-.100000000e52", the direct parse()
-    # is "-1e51" rather than a small value near 0
-    if contains(tl[bdidx], "e")
-        tlsp = split(tl[bdidx], 'e')
-        @assert length(tlsp) == 2
-        m.objbound = parse(tlsp[1])^parse(tlsp[2])
+
+    if tl[bdidx] == "-.100000000000E+52" # Special case to handle scientific notation for "0"
+        # If bound value string is "-.100000000E+52", parse() returns "-1e51" rather than a small value near 0
+        stl = split(tl[bdidx], "E")
+        m.objbound = float(stl[1])^float(stl[2])
     else
-        m.objbound = parse(tl[bdidx])
+        m.objbound = float(tl[bdidx])
     end
 
     nothing


### PR DESCRIPTION
Added a method to parse bound from tim.lst as documented in page 13-14 in http://www.minlp.com/downloads/docs/baron%20manual.pdf. 

Saw a special case where tim.lst return lower bound (dual bound) as "-.100000000000E+52", which should be 0. But Julia will consider it as a "very negative" number when parsing.
```
===========================================================================
 Doing local search
 Preprocessing found feasible solution with value -.407176866688E-006
 Solving bounding LP
 Starting multi-start local search
 Done with local search
===========================================================================
  Iteration    Open nodes         Time (s)    Lower bound      Upper bound
===========================================================================
 User did not provide appropriate variable bounds. 
 Some model expressions are unbounded.             
 We may not be able to guarantee globality.        
 Number of missing variable or expression bounds =     15
 Number of variable or expression bounds autoset =     15
===========================================================================
          1             1             2.00    -6.11308         -0.407177E-06
*       494            88             2.86    -0.421280E-01    -0.333700E-04
       1320             0             3.91    -0.343700E-04    -0.333700E-04

 Cleaning up

                         *** Normal completion ***            

 Wall clock time:                     4.00
 Total CPU time used:                 3.91

 Total no. of BaR iterations:    1320
 Best solution found at node:     494
 Max. no. of nodes in memory:     109
 
 All done
===========================================================================
tl = SubString{String}["problem", "5", "7", "167", "29", "-.100000000000E+52", "-.333700197003E-04", "1", "4", "2", "1320", "494", "109", "3.9", "4"]
```
