### PR TITLE
Use unique temporary directories.

### DIFF
--- a/src/BARON.jl
+++ b/src/BARON.jl
@@ -49,7 +49,7 @@ mutable struct BaronMathProgModel <: AbstractNonlinearModel
     d::AbstractNLPEvaluator
 
     function BaronMathProgModel(;options...)
-        dir = tempdir()
+        dir = mktempdir()
         push!(options, (:ResName, joinpath(dir, "res.lst")))
         push!(options, (:TimName, joinpath(dir, "tim.lst")))
         push!(options, (:SumName, joinpath(dir, "sum.lst")))
@@ -129,7 +129,7 @@ function MathProgBase.loadproblem!(m::BaronMathProgModel,
         verify_support(MathProgBase.constr_expr(d,c))
     end
 
-    dir = tempdir()
+    dir = mktempdir()
     m.probfile = joinpath(dir, "baron_problem.bar")
     m.sumfile  = joinpath(dir, "sum.lst")
     m.resfile  = joinpath(dir, "res.lst")

--- a/src/BARON.jl
+++ b/src/BARON.jl
@@ -36,6 +36,7 @@ mutable struct BaronMathProgModel <: AbstractNonlinearModel
 
     x₀::Vector{Float64}
 
+    tmpdir::String
     probfile::String
     sumfile::String
     resfile::String
@@ -49,10 +50,10 @@ mutable struct BaronMathProgModel <: AbstractNonlinearModel
     d::AbstractNLPEvaluator
 
     function BaronMathProgModel(;options...)
-        dir = mktempdir()
-        push!(options, (:ResName, joinpath(dir, "res.lst")))
-        push!(options, (:TimName, joinpath(dir, "tim.lst")))
-        push!(options, (:SumName, joinpath(dir, "sum.lst")))
+        tmpdir = mktempdir()
+        push!(options, (:ResName, joinpath(tmpdir, "res.lst")))
+        push!(options, (:TimName, joinpath(tmpdir, "tim.lst")))
+        push!(options, (:SumName, joinpath(tmpdir, "sum.lst")))
         new(options,
         zeros(0),
         zeros(0),
@@ -67,8 +68,9 @@ mutable struct BaronMathProgModel <: AbstractNonlinearModel
         String[],
         :Min,
         zeros(0),
+        tmpdir,
         "",
-         "",
+        "",
         "",
         NaN,
         NaN,
@@ -129,10 +131,9 @@ function MathProgBase.loadproblem!(m::BaronMathProgModel,
         verify_support(MathProgBase.constr_expr(d,c))
     end
 
-    dir = dirname(m.options[1][2])
-    m.probfile = joinpath(dir, "baron_problem.bar")
-    m.sumfile  = joinpath(dir, "sum.lst")
-    m.resfile  = joinpath(dir, "res.lst")
+    m.probfile = joinpath(m.tmpdir, "baron_problem.bar")
+    m.sumfile  = joinpath(m.tmpdir, "sum.lst")
+    m.resfile  = joinpath(m.tmpdir, "res.lst")
     m
 end
 

--- a/src/BARON.jl
+++ b/src/BARON.jl
@@ -129,7 +129,7 @@ function MathProgBase.loadproblem!(m::BaronMathProgModel,
         verify_support(MathProgBase.constr_expr(d,c))
     end
 
-    dir = mktempdir()
+    dir = dirname(m.options[1][2])
     m.probfile = joinpath(dir, "baron_problem.bar")
     m.sumfile  = joinpath(dir, "sum.lst")
     m.resfile  = joinpath(dir, "res.lst")


### PR DESCRIPTION
On most UNIX systems, `tempdir()` returns `/tmp`. Since the filenames that correspond to a BARON model are fixed ("baron_problem.bar", "res.lst", "tim.lst"), there is ambiguity when performing multiple solves in parallel. That is, the wrong `m.probfile` could be used when running `MathProgBase.optimize`.

Use of `mktempdir()` instead of `tempdir()` avoids this problem.