### PR TITLE
Fixes for 0.7/1.0

### DIFF
--- a/src/BARON.jl
+++ b/src/BARON.jl
@@ -14,7 +14,7 @@ BaronSolver(;kwargs...) = BaronSolver(kwargs)
 const baron_exec = ENV["BARON_EXEC"]
 
 mutable struct BaronMathProgModel <: AbstractNonlinearModel
-    options
+    options::Dict{Symbol, Any}
 
     xˡ::Vector{Float64}
     xᵘ::Vector{Float64}

--- a/src/BARON.jl
+++ b/src/BARON.jl
@@ -49,34 +49,35 @@ mutable struct BaronMathProgModel <: AbstractNonlinearModel
 
     d::AbstractNLPEvaluator
 
-    function BaronMathProgModel(;options...)
+    function BaronMathProgModel(;kwargs...)
         tmpdir = mktempdir()
-        push!(options, (:ResName, joinpath(tmpdir, "res.lst")))
-        push!(options, (:TimName, joinpath(tmpdir, "tim.lst")))
-        push!(options, (:SumName, joinpath(tmpdir, "sum.lst")))
+        options = Dict{Symbol, Any}(kwargs)
+        get!(options, :ResName, joinpath(tmpdir, "res.lst"))
+        get!(options, :TimName, joinpath(tmpdir, "tim.lst"))
+        get!(options, :SumName, joinpath(tmpdir, "sum.lst"))
         new(options,
-        zeros(0),
-        zeros(0),
-        zeros(0),
-        zeros(0),
-        0,
-        0,
-        :(0),
-        Expr[],
-        Symbol[],
-        String[],
-        String[],
-        :Min,
-        zeros(0),
-        tmpdir,
-        "",
-        "",
-        "",
-        NaN,
-        NaN,
-        [NaN],
-        0.0,
-        :NotSolved)
+            zeros(0),
+            zeros(0),
+            zeros(0),
+            zeros(0),
+            0,
+            0,
+            :(0),
+            Expr[],
+            Symbol[],
+            String[],
+            String[],
+            :Min,
+            zeros(0),
+            tmpdir,
+            "",
+            "",
+            "",
+            NaN,
+            NaN,
+            [NaN],
+            0.0,
+            :NotSolved)
     end
 end
 
@@ -388,15 +389,15 @@ function read_results(m::BaronMathProgModel)
             isempty(parts) && break
             mt = match(r"\d+", parts[1])
             mt == nothing && error("Cannot find appropriate variable index from $(parts[1])")
-            v_idx = parse(Int,mt.match)
-            v_val = float(parts[3])
+            v_idx = parse(Int, mt.match)
+            v_val = parse(Float64, parts[3])
             x[v_idx] = v_val
         end
         m.solution = x
         line = readline(fp)
         val = match(r"[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?", chomp(line))
         if val != nothing
-            m.objval = float(val.match)
+            m.objval = parse(Float64, val.match)
         end
     end
     nothing

--- a/test/gear.jl
+++ b/test/gear.jl
@@ -1,4 +1,6 @@
-using JuMP, BARON, Base.Test
+module Gear
+
+using JuMP, BARON, Compat.Test
 
 m = Model(solver=BaronSolver())
 ub = [2, 2, 1]
@@ -12,3 +14,5 @@ end)
 @NLobjective(m, Min, 6.931 - x[1]*x[2]/(x[3]*x[4])^2 + 1)
 
 solve(m)
+
+end # module

--- a/test/minlp.jl
+++ b/test/minlp.jl
@@ -1,4 +1,6 @@
-using JuMP, BARON, Base.Test
+module MINLP
+
+using JuMP, BARON, Compat.Test
 
 m = Model(solver=BaronSolver())
 ub = [2, 2, 1]
@@ -14,7 +16,9 @@ ub = [2, 2, 1]
        y[1] + y[2] ≤ 1
 end)
 
-@NLobjective(m, Min, 5y[1] + 6y[2] + 8y[3] + 10x[1] - 7x[3] - 18log(x[2]+1) - 
+@NLobjective(m, Min, 5y[1] + 6y[2] + 8y[3] + 10x[1] - 7x[3] - 18log(x[2]+1) -
                         19.2log(x[1]-x[2]+1) + 10)
 
 solve(m)
+
+end # module

--- a/test/nlp1.jl
+++ b/test/nlp1.jl
@@ -1,4 +1,6 @@
-using JuMP, BARON, Base.Test
+module NLP1
+
+using JuMP, BARON, Compat.Test
 
 m = Model(solver=BaronSolver())
 ub = [6,4]
@@ -13,3 +15,5 @@ solve(m)
 @test isapprox(getvalue(x[1]), 6, rtol=1e-6)
 @test isapprox(getvalue(x[2]), 2/3, rtol=1e-6)
 @test isapprox(getobjectivevalue(m), -20/3, rtol=1e-6)
+
+end # module

--- a/test/nlp2.jl
+++ b/test/nlp2.jl
@@ -1,4 +1,6 @@
-using JuMP, BARON, Base.Test
+module NLP2
+
+using JuMP, BARON, Compat.Test
 
 m = Model(solver=BaronSolver())
 ub = [9.422, 5.9023, 267.417085245]
@@ -18,3 +20,5 @@ solve(m)
 @test isapprox(getvalue(x[2]), 3.8218391, rtol=1e-6)
 @test isapprox(getvalue(x[3]), 201.1593341, rtol=1e-5)
 @test isapprox(getobjectivevalue(m), -201.1593341, rtol=1e-6)
+
+end # module

--- a/test/pool1.jl
+++ b/test/pool1.jl
@@ -1,3 +1,5 @@
+module Pool1
+
 using JuMP, BARON
 
 m = Model(solver=BaronSolver())
@@ -17,3 +19,5 @@ end)
 @NLobjective(m, Min, 6x[1] + 16x[2] - 9x[3] - 10x[4])
 
 solve(m)
+
+end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,5 @@
+include("gear.jl")
+include("minlp.jl")
+include("nlp1.jl")
+include("nlp2.jl")
+include("pool1.jl")


### PR DESCRIPTION
* keyword arguments are no longer an `Array{Any}`. Instead of converting the keyword arguments to an `Array{Any}`, I feel like a `Dict{Symbol, Any}` makes more sense. Seems to be working.
* need `parse(Float64, str)` instead of `float(str)` on 0.7/1.0
* add `runtests.jl` file. Enclose individual test files in modules and include the files from `runtests.jl`.
* `Base.Test` -> `Compat.Test`

Tests pass locally.