### PR TITLE
Fix build path on Windows

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -5,5 +5,5 @@ else
 end
 
 open(joinpath(@__DIR__, "path.jl"), "w") do io
-    write(io, """const baron_exec = "$path"\n""")
+    write(io, """const baron_exec = $(repr(path))\n""")
 end


### PR DESCRIPTION
as noticed in https://discourse.julialang.org/t/baron-error-ioerror-could-not-spawn/44430, the path that gets written only has single `/` instead of `//` on Windows.

I tested this new way locally on Windows and WSL via
```julia
path = pwd()
open("file.txt", "w") do io
    write(io, """const baron_exec = $(repr(path))\n""")
end
```
and it escapes things correctly in each case (`const baron_exec = "C:\\Users\\eric\\Code"` on Windows and `const baron_exec = "/mnt/c/Users/eric"` in WSL).